### PR TITLE
Add docs for Crusher runs

### DIFF
--- a/scripts/setenv_crusher.sh
+++ b/scripts/setenv_crusher.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+# Crusher uses MI250X
+# for more information: 
+# https://docs.olcf.ornl.gov/systems/crusher_quick_start_guide.html#gpu-aware-mpi
+
+module load craype-accel-amd-gfx90a
+module load cray-mpich
+module load rocm
+
+# ROCm-aware MPI set to 1, else 0
+export MPICH_GPU_SUPPORT_ENABLED=1
+
+# Use system provided rocm module capabilities
+export JULIA_AMDGPU_DISABLE_ARTIFACTS=1
+export IGG_ROCMAWARE_MPI=1
+
+echo "ENV setup done"

--- a/startup_crusher.sh
+++ b/startup_crusher.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+source ./scripts/setenv_crusher.sh
+
+touch Project.toml
+
+julia --project -e 'using Pkg; pkg"add https://github.com/JuliaParallel/MPI.jl#master";'
+
+julia --project -e 'using Pkg; pkg"add MPIPreferences";'
+
+# libmpi_cray might be recognized automatically
+julia --project -e 'using MPIPreferences; MPIPreferences.use_system_binary(; library_names=["libmpi_cray"], mpiexec="srun")'
+
+julia --project -e 'using Pkg; pkg"add https://github.com/luraess/ImplicitGlobalGrid.jl#lr/amdgpu-0.4.0-compat"; pkg"add AMDGPU";'
+
+julia --project -e 'using Pkg; pkg"add Plots";'
+
+julia --project -e 'using Pkg; Pkg.build()'


### PR DESCRIPTION
ROCm-aware MPI documentation for running on Crusher  (Frontier's test bed)